### PR TITLE
Use context manager when reading HTML report

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -410,7 +410,8 @@ def main():
         else:
             raise FileNotFoundError(f"File HTML non trovato: {INPUT_HTML} (cwd) o {alt} (script dir)")
 
-    soup = BeautifulSoup(open(html, "r", encoding="utf-8"), "html.parser")
+    with html.open("r", encoding="utf-8") as f:
+        soup = BeautifulSoup(f, "html.parser")
 
     # Tempi di sessione
     start_dt = stop_dt = rep_dt = None


### PR DESCRIPTION
## Summary
- replace `open` call with `Path.open` context manager when parsing the HTML report

## Testing
- `python -m py_compile Extract_all_charts.py`
- `python Extract_all_charts.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas bs4 openpyxl xlwt` *(fails: Could not find a version that satisfies the requirement numpy; Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a85876e8d08330b2c1cb4c8380f70d