### PR TITLE
Add safe log file path and document location

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,5 @@ Un'interfaccia Tkinter è disponibile per elaborare più cartelle.
 4. Premere **Run** per generare gli Excel; ogni file salvato verrà segnalato.
 5. La GUI richiede `tkinter`. Se non è già presente, installarlo come indicato nella sezione *Dipendenze*.
 
+I log dell'applicazione sono salvati nel file `gui_app.log` nella stessa directory dello script. Se il file non è scrivibile, i messaggi vengono mostrati solo in console.
+

--- a/gui_app.py
+++ b/gui_app.py
@@ -5,13 +5,17 @@ import logging
 from Extract_all_charts import process_html, INPUT_HTML
 
 
+LOG_PATH = Path(__file__).resolve().with_name("gui_app.log")
+LOG_PATH.parent.mkdir(parents=True, exist_ok=True)
+handlers = [logging.StreamHandler()]
+try:
+    handlers.insert(0, logging.FileHandler(LOG_PATH))
+except OSError as exc:  # pragma: no cover - log fallback
+    print(f"Impossibile scrivere il file di log: {exc}")
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
-    handlers=[
-        logging.FileHandler("gui_app.log"),
-        logging.StreamHandler(),
-    ],
+    handlers=handlers,
     force=True,
 )
 


### PR DESCRIPTION
## Summary
- configure logging to write to `gui_app.log` in script directory
- fall back to console logging if file is unwritable
- document log file location in README

## Testing
- `python -m py_compile gui_app.py Extract_all_charts.py`

------
https://chatgpt.com/codex/tasks/task_e_68a8622bd5d08330b52ee340463d63eb