### PR TITLE
feat: allow directory selection for HTML reports

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -31,7 +31,7 @@ from bs4 import BeautifulSoup
 from openpyxl.chart import ScatterChart, Reference, Series
 
 
-INPUT_HTML = Path("report.html")  # cambia qui se vuoi un altro nome/percorso
+DEFAULT_HTML = Path("report.html")  # used if directory lacks .html
 
 logging.basicConfig(level=logging.INFO)
 
@@ -563,11 +563,11 @@ def main_cli():
         description="Estrae i grafici da un report HTML e li salva in un Excel unico."
     )
     parser.add_argument(
-        "html_path",
+        "path",
         nargs="?",
-        default=INPUT_HTML,
+        default=Path("."),
         type=Path,
-        help="Percorso del file HTML da elaborare (default: report.html)",
+        help="File HTML o directory contenente l'HTML (default: cartella corrente)",
     )
     parser.add_argument(
         "-o",
@@ -577,7 +577,16 @@ def main_cli():
         help="Directory in cui salvare l'Excel (default: cartella corrente)",
     )
     args = parser.parse_args()
-    out_path = process_html(args.html_path, args.output_dir)
+
+    html_path = args.path
+    if html_path.is_dir():
+        html_files = sorted(html_path.glob("*.html"))
+        if html_files:
+            html_path = html_files[0]
+        else:
+            html_path = html_path / DEFAULT_HTML
+
+    out_path = process_html(html_path, args.output_dir)
     logging.info("Salvato: %s", out_path)
 
 

--- a/gui_app.py
+++ b/gui_app.py
@@ -3,7 +3,7 @@ from tkinter import Tk, Listbox, Button, Label, filedialog, Frame
 from tkinter.scrolledtext import ScrolledText
 import logging
 
-from Extract_all_charts import process_html, INPUT_HTML
+from Extract_all_charts import process_html
 
 
 LOG_PATH = Path(__file__).resolve().with_name("gui_app.log")
@@ -111,7 +111,17 @@ def main():
         saved = []
         for i in range(listbox.size()):
             folder = Path(listbox.get(i))
-            report = folder / INPUT_HTML.name
+            html_files = sorted(folder.glob("*.html"))
+            if not html_files:
+                logging.warning("No HTML file in %s", folder)
+                continue
+            if len(html_files) > 1:
+                logging.warning(
+                    "Multiple HTML files in %s; using %s",
+                    folder,
+                    html_files[0].name,
+                )
+            report = html_files[0]
             try:
                 out = process_html(report, output_dir["path"])
                 logging.info("Saved: %s", out)


### PR DESCRIPTION
## Summary
- let GUI pick the first HTML file in each selected folder and warn when none or multiple are present
- support passing a directory to the CLI; it scans for the first HTML report or defaults to `report.html`

## Testing
- `python -m py_compile gui_app.py Extract_all_charts.py`
- `python Extract_all_charts.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas beautifulsoup4 openpyxl` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68a88094e3fc83308d75d885554f7227