### PR TITLE
Add placeholder for output folder label in GUI

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -52,7 +52,7 @@ def main():
     lbl_input = Label(main_frame, anchor="w", text="Input folder:")
     lbl_input.pack(fill="x", padx=5, pady=5)
 
-    lbl_output = Label(main_frame, anchor="w", text="Output folder:")
+    lbl_output = Label(main_frame, anchor="w", text="Output folder: <none>")
     lbl_output.pack(fill="x", padx=5, pady=5)
 
     lbl_count = Label(main_frame)


### PR DESCRIPTION
## Summary
- show "Output folder: <none>" label initially
- ensure output selector updates label to chosen folder

## Testing
- `python -m py_compile gui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8c91901808330b934534213be25bb