### PR TITLE
Align output field styling with listbox

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -50,7 +50,13 @@ def main():
     listbox.pack(fill="x", padx=5, pady=5)
 
     output_var = StringVar()
-    txt_output = Entry(main_frame, textvariable=output_var, state="readonly")
+    txt_output = Entry(
+        main_frame,
+        textvariable=output_var,
+        state="readonly",
+        readonlybackground="white",
+        width=60,
+    )
     txt_output.pack(fill="x", padx=5, pady=5)
 
     lbl_count = Label(main_frame)


### PR DESCRIPTION
## Summary
- Match output entry width with listbox and keep both stretched horizontally
- Ensure the read-only output field uses a white background

## Testing
- `python -m py_compile gui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8ce9c9730833095bb2532946873eb