### PR TITLE
Use safe sheet deletion

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -555,9 +555,8 @@ def process_html(html_path: Path, output_dir: Path) -> Path:
                 chart_sheet = wb.create_chartsheet(csheet)
                 chart_sheet.add_chart(chart)
 
-            default = wb.get_sheet_by_name("Sheet")
-            if default:
-                wb.remove(default)
+            if "Sheet" in wb.sheetnames:
+                wb.remove(wb["Sheet"])
 
     return out_path
 


### PR DESCRIPTION
## Summary
- remove deprecated `get_sheet_by_name` usage
- safely remove default 'Sheet' with conditional check

## Testing
- `python Extract_all_charts.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas beautifulsoup4 openpyxl` *(fails: Could not find a version that satisfies the requirement numpy)*
- `python gui_app.py` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68a8d498269c83309007ef89cf331655