### PR TITLE
Add azimuth and elevation chart extraction

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -465,6 +465,8 @@ def process_html(html_path: Path, output_dir: Path) -> Path:
         ("_frame_error_rate", "Frame Error Rate", "fer"),
         ("_demodulator_lock_state", "Demodulator Lock State", "lock_state"),
         ("_fep_lock_state", "FEP Lock State", "fep_lock_state"),
+        ("_azimuth", "Azimuth", "azimuth_deg"),
+        ("_elevation", "Elevation", "elevation_deg"),
     ]
 
     # Nome file in base a (prefix, orbit_no) trovati nell'HTML


### PR DESCRIPTION
## Summary
- include azimuth and elevation targets so their charts are exported to Excel

## Testing
- `python Extract_all_charts.py report.html` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas beautifulsoup4 openpyxl` *(fails: Could not find a version that satisfies the requirement numpy due to proxy restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68a8dcf53fa083309360d1f7729a705b