### PR TITLE
Handle degree symbols in tick parsing

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -182,7 +182,7 @@ def svg_axes_from_ticks(svg):
         content = (t.get_text() or "").strip()
         if not content:
             continue
-        is_num = re.fullmatch(r"[-+]?\d+(\.\d+)?", content) is not None or content.lstrip("+-").isdigit()
+        is_num = re.fullmatch(r"[-+]?\d+(?:\.\d+)?(?:°)?", content) is not None
         is_time = (
             re.fullmatch(r"\d{2}:\d{2}", content) is not None or
             re.fullmatch(r"\d{2}:\d{2}:\d{2}", content) is not None
@@ -327,7 +327,9 @@ def map_y_from_ticks(df: pd.DataFrame, ticks: pd.DataFrame, colname: str):
     if y_ticks.empty:
         df[colname] = np.nan
         return df
-    y_ticks["value"] = y_ticks["text"].astype(float)
+    y_ticks["value"] = (
+        y_ticks["text"].str.replace(r"[^0-9.+-]", "", regex=True).astype(float)
+    )
     Y = np.vstack([y_ticks["y_px"].values, np.ones(len(y_ticks))]).T
     a, b = np.linalg.lstsq(Y, y_ticks["value"].values, rcond=None)[0]
     df[colname] = a * df["y_px"] + b


### PR DESCRIPTION
## Summary
- recognize degree suffix in SVG tick labels
- strip non-numeric characters before converting Y-axis tick text to floats

## Testing
- `python -m py_compile Extract_all_charts.py`
- `pip install numpy pandas beautifulsoup4` *(fails: 403 Forbidden)*
- `python - <<'PY'` (regex validation)


------
https://chatgpt.com/codex/tasks/task_e_68a8ddb25c248330bcaecbee70a21ea4