### PR TITLE
Use ttk PanedWindow pane method for minsize

### DIFF
--- a/gui_app.py
+++ b/gui_app.py
@@ -47,7 +47,7 @@ def main():
 
     main_frame = ttk.Frame(paned)
     paned.add(main_frame, weight=3)
-    paned.paneconfigure(main_frame, minsize=120)
+    paned.pane(main_frame, minsize=120)
     main_frame.grid_columnconfigure(0, weight=1)
     for r in range(3):
         main_frame.grid_rowconfigure(r, weight=1, minsize=30)
@@ -83,7 +83,7 @@ def main():
 
     log_frame = ttk.Frame(paned)
     paned.add(log_frame, weight=1)
-    paned.paneconfigure(log_frame, minsize=80)
+    paned.pane(log_frame, minsize=80)
     log_frame.grid_rowconfigure(0, weight=1)
     log_frame.grid_columnconfigure(0, weight=1)
     log_panel = Text(log_frame, state="disabled")


### PR DESCRIPTION
## Summary
- Replace deprecated `paneconfigure` calls with `pane` when setting minimum sizes for paned window frames

## Testing
- `python gui_app.py` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a8e65d7fb08330ad0059ce40fb48c0