### PR TITLE
Handle generic SVG groups in curve extraction

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -263,7 +263,13 @@ def extract_curve_for_header_id(soup: BeautifulSoup, hdr_id: str):
     best_pts = []
     best_score = -1
 
-    groups = [g for g in best_svg.find_all("g") if (g.get("id") or "").startswith("gnuplot_plot_")]
+    groups = [
+        g
+        for g in best_svg.find_all("g")
+        if (g.get("id") or "").startswith("gnuplot_plot_") and (g.find("path") or g.find("polyline"))
+    ]
+    if not groups:
+        groups = [g for g in best_svg.find_all("g") if g.find("path") or g.find("polyline")]
     for g in groups:
         # PATH: split in subpath e valuta punti dentro assi
         for p in g.find_all("path"):


### PR DESCRIPTION
## Summary
- Expand curve extraction to include any `<g>` with `<path>` or `<polyline>` elements
- Prefer `gnuplot_plot_*` groups when present, but fall back to generic groups

## Testing
- ❌ `python Extract_all_charts.py report.html` (ModuleNotFoundError: No module named 'numpy')
- ⚠️ `pip install beautifulsoup4 pandas numpy` (Could not fetch packages: 403 Forbidden)
- ⚠️ `apt-get update` (Failed to fetch repositories: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68ac16457e808330bc379b05f74f1f7e