### PR TITLE
Gracefully fallback when lxml is unavailable

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -28,7 +28,7 @@ import urllib.request
 
 import numpy as np
 import pandas as pd
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, FeatureNotFound
 
 
 DEFAULT_HTML = Path("report.html")  # used if directory lacks .html
@@ -239,7 +239,20 @@ def extract_curve_for_header(hdr):
                         svg_bytes = f.read()
                 else:
                     continue
-                svg_soup = BeautifulSoup(svg_bytes, "xml")
+                try:
+                    svg_soup = BeautifulSoup(svg_bytes, "xml")
+                except FeatureNotFound:
+                    logger.warning(
+                        "lxml parser not found; falling back to html.parser. Install lxml for full XML support."
+                    )
+                    try:
+                        svg_soup = BeautifulSoup(svg_bytes, "html.parser")
+                    except FeatureNotFound:
+                        import xml.etree.ElementTree as ET
+
+                        svg_soup = BeautifulSoup(
+                            ET.tostring(ET.fromstring(svg_bytes)), "html.parser"
+                        )
                 if svg_soup.svg:
                     svgs.append(svg_soup.svg)
             except Exception as exc:


### PR DESCRIPTION
## Summary
- ensure BeautifulSoup import exposes FeatureNotFound
- fall back to `html.parser` (with ElementTree as a backup) when `lxml` is missing and log a warning

## Testing
- `python -m py_compile Extract_all_charts.py`
- `python Extract_all_charts.py --help` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ac412d47308330856451e497131767