### PR TITLE
Exclude session and similar sections from chart extraction

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -515,6 +515,9 @@ def process_html(html_path: Path, output_dir: Path) -> Path:
         if not has_chart:
             continue
         key = re.sub(r"\W+", "_", title.lower()).strip("_") or "section"
+        EXCLUDE = {"session", "activities", "channel"}
+        if key in EXCLUDE or any(key.endswith(f"_{e}") for e in EXCLUDE):
+            continue
         targets.append((hdr, key))
 
     # Nome file in base a (prefix, orbit_no) trovati nell'HTML


### PR DESCRIPTION
## Summary
- skip adding `session`, `activities`, and `channel` headers (or their suffix variants) to chart extraction targets

## Testing
- `python Extract_all_charts.py report.html` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy pandas beautifulsoup4 openpyxl` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4516c2d083309d3d0eaaa04c5fb0