### PR TITLE
Handle missing __file__ in meos_extract spec

### DIFF
--- a/meos_extract.spec
+++ b/meos_extract.spec
@@ -2,8 +2,9 @@
 # Generate the executables with:  pyinstaller meos_extract.spec
 
 from pathlib import Path
+import sys
 block_cipher = None
-project_root = Path(__file__).parent
+project_root = Path(__file__).resolve().parent if "__file__" in globals() else Path.cwd()
 
 # --- CLI analysis/executable ---
 a_cli = Analysis(


### PR DESCRIPTION
## Summary
- make `project_root` fall back to the current working directory when `__file__` is undefined

## Testing
- `pyinstaller meos_extract.spec` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68ac4c10cbf083309dab48d343513f89