### PR TITLE
Add license validation step

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -25,10 +25,12 @@ from datetime import datetime, timezone, timedelta
 import logging
 import base64
 import urllib.request
+import sys
 
 import numpy as np
 import pandas as pd
 from bs4 import BeautifulSoup, FeatureNotFound
+from license_checker import validate_license
 
 
 DEFAULT_HTML = Path("report.html")  # used if directory lacks .html
@@ -725,6 +727,10 @@ def main_cli():
         help="Directory in cui salvare l'Excel (default: cartella corrente)",
     )
     args = parser.parse_args()
+
+    if not validate_license(Path("license.key")):
+        logging.error("Invalid or missing license.")
+        sys.exit(1)
 
     html_path = args.path
     if html_path.is_dir():

--- a/README.md
+++ b/README.md
@@ -33,7 +33,19 @@ Un'interfaccia Tkinter è disponibile per elaborare più cartelle.
 
 I log dell'applicazione sono salvati nel file `gui_app.log` nella stessa directory dello script. Se il file non è scrivibile, i messaggi vengono mostrati solo in console.
 
+## File di licenza
+
+Il programma richiede un file `license.key` nella stessa cartella di `Extract_all_charts.py` o `gui_app.py`.
+Il file deve contenere la stringa esadecimale generata con la stessa chiave segreta usata dall'applicazione:
+
+```python
+import hmac, hashlib
+secret = b"demo-secret"  # sostituire con il proprio segreto
+print(hmac.new(secret, b"MEOS-Extract", hashlib.sha256).hexdigest())
+```
+
+Salvare l'output in `license.key`. Se il file manca o la chiave non è valida l'esecuzione termina con errore.
 
 ## Licenza
 
-Questo progetto è distribuito con licenza [MIT](LICENSE). Non è richiesto alcun file di attivazione.
+Questo progetto è distribuito con licenza [MIT](LICENSE).

--- a/license_checker.py
+++ b/license_checker.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from pathlib import Path
+import hmac
+import hashlib
+
+# Secret key used to sign license files. Replace with your own secret in production.
+SECRET_KEY = b"demo-secret"
+
+def load_license(path: Path) -> str | None:
+    """Return the license string from *path* or ``None`` if not found."""
+    try:
+        return path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+
+def validate_license(path: Path) -> bool:
+    """Validate the license file using HMAC/SHA256.
+
+    The license must contain the hex digest of ``HMAC(SECRET_KEY, b"MEOS-Extract")``.
+    """
+    key = load_license(path)
+    if not key:
+        return False
+    expected = hmac.new(SECRET_KEY, b"MEOS-Extract", hashlib.sha256).hexdigest()
+    return hmac.compare_digest(key, expected)


### PR DESCRIPTION
## Summary
- add `license_checker` module to load and verify HMAC-based license keys
- enforce license validation at startup in `Extract_all_charts.py`
- document license key placement and generation in README

## Testing
- `python -m py_compile license_checker.py Extract_all_charts.py`
- `python - <<'PY'
from pathlib import Path
from license_checker import validate_license
print(validate_license(Path('license.key')))
PY`
- `pip install numpy pandas beautifulsoup4 openpyxl` *(failed: Cannot connect to proxy, missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5e683a508330bcf5c0b48e6fc024