### PR TITLE
Add license generation script with HMAC signing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Ignore generated license and secret key files
+license.key
+secret.key
+
+# Bytecode
+__pycache__/
+*/__pycache__/

--- a/license_checker.py
+++ b/license_checker.py
@@ -3,24 +3,44 @@ from __future__ import annotations
 from pathlib import Path
 import hmac
 import hashlib
+import json
+from datetime import datetime, date
 
 # Secret key used to sign license files. Replace with your own secret in production.
 SECRET_KEY = b"demo-secret"
 
-def load_license(path: Path) -> str | None:
-    """Return the license string from *path* or ``None`` if not found."""
+def load_license(path: Path) -> dict[str, str] | None:
+    """Return the license information from *path* or ``None`` if not found."""
     try:
-        return path.read_text(encoding="utf-8").strip()
-    except OSError:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
         return None
 
 def validate_license(path: Path) -> bool:
     """Validate the license file using HMAC/SHA256.
 
-    The license must contain the hex digest of ``HMAC(SECRET_KEY, b"MEOS-Extract")``.
+    The license file must contain ``client``, ``expires`` and ``signature`` fields.
+    The signature is expected to be the hex digest of
+    ``HMAC(SECRET_KEY, f"{client}|{expires}")``.
     """
-    key = load_license(path)
-    if not key:
+    lic = load_license(path)
+    if not lic:
         return False
-    expected = hmac.new(SECRET_KEY, b"MEOS-Extract", hashlib.sha256).hexdigest()
-    return hmac.compare_digest(key, expected)
+
+    client = lic.get("client")
+    expires = lic.get("expires")
+    signature = lic.get("signature")
+    if not (client and expires and signature):
+        return False
+
+    payload = f"{client}|{expires}".encode("utf-8")
+    expected = hmac.new(SECRET_KEY, payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(signature, expected):
+        return False
+
+    try:
+        exp_date = datetime.strptime(expires, "%Y-%m-%d").date()
+    except ValueError:
+        return False
+
+    return date.today() <= exp_date

--- a/scripts/generate_license.py
+++ b/scripts/generate_license.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Generate a signed license file.
+
+This script is intended for internal use to produce ``license.key`` files.
+It reads a secret key from a file, signs the provided license metadata using
+HMAC/SHA256, and writes the result to ``license.key``.
+
+The secret key file **must** be stored securely and should not be distributed
+with the application or committed to source control.
+"""
+from __future__ import annotations
+
+import argparse
+import hmac
+import hashlib
+import json
+from pathlib import Path
+from datetime import datetime
+
+def load_secret(path: Path) -> bytes:
+    try:
+        return path.read_bytes().strip()
+    except OSError as exc:
+        raise SystemExit(f"Unable to read secret key: {exc}")
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a signed license file")
+    parser.add_argument("--client", required=True, help="Client name")
+    parser.add_argument(
+        "--expires", required=True, help="Expiration date in YYYY-MM-DD format"
+    )
+    parser.add_argument(
+        "--secret-file", required=True, help="Path to file containing HMAC secret"
+    )
+    parser.add_argument(
+        "--output", default="license.key", help="Output path for license file"
+    )
+    args = parser.parse_args()
+
+    # Validate expiration date format
+    try:
+        datetime.strptime(args.expires, "%Y-%m-%d")
+    except ValueError as exc:
+        raise SystemExit(f"Invalid --expires value: {exc}")
+
+    secret = load_secret(Path(args.secret_file))
+
+    payload = f"{args.client}|{args.expires}".encode("utf-8")
+    signature = hmac.new(secret, payload, hashlib.sha256).hexdigest()
+
+    license_data = {"client": args.client, "expires": args.expires, "signature": signature}
+    Path(args.output).write_text(json.dumps(license_data), encoding="utf-8")
+    print(f"License written to {args.output}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to generate `license.key` files from client info, signed using HMAC
- update license checker to validate signed JSON license with expiration
- ignore generated keys and secrets in git

## Testing
- `python scripts/generate_license.py --client Alice --expires 2099-01-01 --secret-file secret.key`
- `python - <<'PY'
from pathlib import Path
import license_checker
print(license_checker.validate_license(Path('license.key')))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68ac5f7859348330bc457192197bb83c