### PR TITLE
Centralize license validation and remove demo key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore generated secret key files
 secret.key
+license.key
 
 # Bytecode
 __pycache__/

--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -25,12 +25,11 @@ from datetime import datetime, timezone, timedelta
 import logging
 import base64
 import urllib.request
-import sys
 
 import numpy as np
 import pandas as pd
 from bs4 import BeautifulSoup, FeatureNotFound
-from license_checker import validate_license
+from license_checker import ensure_valid_license
 
 
 DEFAULT_HTML = Path("report.html")  # used if directory lacks .html
@@ -588,6 +587,7 @@ def process_html(html_path: Path, output_dir: Path) -> Path:
     Path
         Percorso del file Excel creato.
     """
+    ensure_valid_license()
     html = Path(html_path)
     if not html.exists():
         alt = Path(__file__).resolve().parent / html.name
@@ -727,10 +727,6 @@ def main_cli():
         help="Directory in cui salvare l'Excel (default: cartella corrente)",
     )
     args = parser.parse_args()
-
-    if not validate_license(Path("license.key")):
-        logging.error("Invalid or missing license.")
-        sys.exit(1)
 
     html_path = args.path
     if html_path.is_dir():

--- a/gui_app.py
+++ b/gui_app.py
@@ -14,8 +14,10 @@ from pathlib import Path
 from tkinter import Tk, Listbox, filedialog, StringVar, Text, PanedWindow
 from tkinter import ttk
 import logging
+import sys
 
 from Extract_all_charts import process_html
+from license_checker import validate_license
 
 
 LOG_PATH = Path(__file__).resolve().with_name("gui_app.log")
@@ -49,6 +51,10 @@ class TextHandler(logging.Handler):
 
 
 def main():
+    if not validate_license(Path("license.key")):
+        logging.error("Invalid or missing license.")
+        sys.exit(1)
+
     # --- Top-level window setup -----------------------------------------
     root = Tk()  # the root window manages the event loop
     root.title("MEOS Extract GUI")

--- a/license.key
+++ b/license.key
@@ -1,5 +1,0 @@
-{
-  "client": "REPLACE_ME",
-  "expires": "2099-12-31",
-  "signature": "replace_with_signature"
-}

--- a/license_checker.py
+++ b/license_checker.py
@@ -58,3 +58,16 @@ def validate_license(path: Path) -> bool:
         return False
 
     return date.today() <= exp_date
+
+
+_VALIDATED = False
+
+
+def ensure_valid_license() -> None:
+    """Exit with ``RuntimeError`` if ``license.key`` is missing or invalid."""
+    global _VALIDATED
+    if _VALIDATED:
+        return
+    if not validate_license(Path("license.key")):
+        raise RuntimeError("Invalid or missing license.")
+    _VALIDATED = True

--- a/meos_extract.spec
+++ b/meos_extract.spec
@@ -12,8 +12,7 @@ a_cli = Analysis(
     ['extract_all_charts.py'],          # main CLI script
     pathex=[str(project_root)],
     binaries=[],
-    datas=[('license.key', '.'),        # bundle sample license
-           ('license_checker.py', '.')],
+    datas=[('license_checker.py', '.')],
     hiddenimports=['bs4', 'pandas', 'numpy', 'openpyxl'],
     hookspath=[],
     hooksconfig={},
@@ -42,8 +41,7 @@ a_gui = Analysis(
     ['gui_app.py'],                       # Tkinter front-end
     pathex=[str(project_root)],
     binaries=[],
-    datas=[('license.key', '.'),          # same extras for GUI build
-           ('license_checker.py', '.')],
+    datas=[('license_checker.py', '.')],
     hiddenimports=['bs4', 'pandas', 'numpy', 'openpyxl'],
     hookspath=[],
     hooksconfig={},


### PR DESCRIPTION
## Summary
- Add `ensure_valid_license()` helper and reuse it in `process_html` for centralized license checks
- Validate license on GUI startup, logging an error and exiting if missing or invalid
- Drop bundled `license.key` from source and PyInstaller spec; ignore in git

## Testing
- `python -m py_compile license_checker.py` (passes)
- `python -m py_compile Extract_all_charts.py` (passes)
- `python -m py_compile gui_app.py` (passes)
- `python -m py_compile meos_extract.spec` (passes)
- `pip install numpy` (fails: Tunnel connection failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68ac78277000833099f229efe8fc3dc9