### PR TITLE
Handle missing license gracefully

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -25,6 +25,7 @@ from datetime import datetime, timezone, timedelta
 import logging
 import base64
 import urllib.request
+import sys
 
 import numpy as np
 import pandas as pd
@@ -587,7 +588,11 @@ def process_html(html_path: Path, output_dir: Path) -> Path:
     Path
         Percorso del file Excel creato.
     """
-    ensure_valid_license()
+    try:
+        ensure_valid_license()
+    except RuntimeError as exc:
+        logging.error("License check failed: %s", exc)
+        sys.exit(1)
     html = Path(html_path)
     if not html.exists():
         alt = Path(__file__).resolve().parent / html.name

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ secret = b"demo-secret"  # sostituire con il proprio segreto
 print(hmac.new(secret, b"MEOS-Extract", hashlib.sha256).hexdigest())
 ```
 
-Salvare l'output in `license.key`. Se il file manca o la chiave non è valida l'esecuzione termina con errore.
+Salvare l'output in `license.key`. Se il file manca o la chiave non è valida
+l'esecuzione termina mostrando "Invalid or missing license".
 
 ## Licenza
 

--- a/gui_app.py
+++ b/gui_app.py
@@ -11,10 +11,9 @@ on the console and inside the GUI.
 """
 
 from pathlib import Path
-from tkinter import Tk, Listbox, filedialog, StringVar, Text, PanedWindow
+from tkinter import Tk, Listbox, filedialog, StringVar, Text, PanedWindow, messagebox
 from tkinter import ttk
 import logging
-import sys
 
 from Extract_all_charts import process_html
 from license_checker import validate_license
@@ -52,8 +51,8 @@ class TextHandler(logging.Handler):
 
 def main():
     if not validate_license(Path("license.key")):
-        logging.error("Invalid or missing license.")
-        sys.exit(1)
+        messagebox.showerror("License error", "Invalid or missing license.")
+        return
 
     # --- Top-level window setup -----------------------------------------
     root = Tk()  # the root window manages the event loop


### PR DESCRIPTION
## Summary
- Exit CLI cleanly if license check fails by logging the error.
- Show a GUI message box when license validation fails instead of exiting abruptly.
- Mention the "Invalid or missing license" message in the documentation.

## Testing
- `python -m py_compile Extract_all_charts.py gui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68acab63ff088330927c46a2c412fdb4