### PR TITLE
chore: temporarily disable license validation

### DIFF
--- a/Extract_all_charts.py
+++ b/Extract_all_charts.py
@@ -23,6 +23,7 @@ import argparse
 import re
 from datetime import datetime, timezone, timedelta
 import logging
+import os
 import base64
 import urllib.request
 import sys
@@ -588,11 +589,17 @@ def process_html(html_path: Path, output_dir: Path) -> Path:
     Path
         Percorso del file Excel creato.
     """
-    try:
-        ensure_valid_license()
-    except RuntimeError as exc:
-        logging.error("License check failed: %s", exc)
-        sys.exit(1)
+    # TODO: re-enable mandatory license validation
+    if not os.environ.get("MEOS_SKIP_LICENSE"):
+        try:
+            ensure_valid_license()
+        except RuntimeError as exc:
+            logging.error("License check failed: %s", exc)
+            sys.exit(1)
+    else:  # pragma: no cover - dev only
+        logger.warning(
+            "License check skipped; TODO: restore license validation"
+        )
     html = Path(html_path)
     if not html.exists():
         alt = Path(__file__).resolve().parent / html.name

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ print(hmac.new(secret, b"MEOS-Extract", hashlib.sha256).hexdigest())
 Salvare l'output in `license.key`. Se il file manca o la chiave non è valida
 l'esecuzione termina mostrando "Invalid or missing license".
 
+**Nota:** al momento il controllo della licenza è disattivato tramite la variabile
+d'ambiente `MEOS_SKIP_LICENSE` ed è previsto che venga riabilitato in seguito.
+
 ## Licenza
 
 Questo progetto è distribuito con licenza [MIT](LICENSE).

--- a/gui_app.py
+++ b/gui_app.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from tkinter import Tk, Listbox, filedialog, StringVar, Text, PanedWindow, messagebox
 from tkinter import ttk
 import logging
+import os
 
 from Extract_all_charts import process_html
 from license_checker import validate_license
@@ -50,9 +51,15 @@ class TextHandler(logging.Handler):
 
 
 def main():
-    if not validate_license(Path("license.key")):
-        messagebox.showerror("License error", "Invalid or missing license.")
-        return
+    # TODO: re-enable mandatory license validation
+    if not os.environ.get("MEOS_SKIP_LICENSE"):
+        if not validate_license(Path("license.key")):
+            messagebox.showerror("License error", "Invalid or missing license.")
+            return
+    else:  # pragma: no cover - dev only
+        logging.warning(
+            "License check skipped; TODO: restore license validation"
+        )
 
     # --- Top-level window setup -----------------------------------------
     root = Tk()  # the root window manages the event loop


### PR DESCRIPTION
## Summary
- guard license checks behind `MEOS_SKIP_LICENSE` flag in CLI and GUI entry points
- document temporary license disablement in README

## Testing
- `python -m py_compile Extract_all_charts.py gui_app.py`


------
https://chatgpt.com/codex/tasks/task_e_68acb95322708330a4a850b494a91e89