### PR TITLE
Fix case sensitivity in PyInstaller spec file

### DIFF
--- a/meos_extract.spec
+++ b/meos_extract.spec
@@ -9,7 +9,7 @@ project_root = Path(__file__).resolve().parent if "__file__" in globals() else P
 
 # ---------------- CLI executable ----------------
 a_cli = Analysis(
-    ['extract_all_charts.py'],          # main CLI script
+    ['Extract_all_charts.py'],          # main CLI script
     pathex=[str(project_root)],
     binaries=[],
     datas=[('license_checker.py', '.')],


### PR DESCRIPTION
## Summary
- Correct CLI script filename case in `meos_extract.spec`

## Testing
- `pyinstaller meos_extract.spec` *(fails: command not found)*
- `python -m pip install pyinstaller` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68acbf96519c8330b46ec6d1f13c96ba